### PR TITLE
fix: correct JSON tags for `Prompt` and `Suffix` in `GeneralOpenAIReq…

### DIFF
--- a/dto/openai_request.go
+++ b/dto/openai_request.go
@@ -17,8 +17,8 @@ type FormatJsonSchema struct {
 type GeneralOpenAIRequest struct {
 	Model               string          `json:"model,omitempty"`
 	Messages            []Message       `json:"messages,omitempty"`
-	Prompt              any             `json:"suffix,omitempty"`
-	Suffix              any             `json:"prompt,omitempty"`
+	Prompt              any             `json:"prompt,omitempty"`
+	Suffix              any             `json:"suffix,omitempty"`
 	Stream              bool            `json:"stream,omitempty"`
 	StreamOptions       *StreamOptions  `json:"stream_options,omitempty"`
 	MaxTokens           uint            `json:"max_tokens,omitempty"`


### PR DESCRIPTION
…uest`